### PR TITLE
Require an exact match for session names when attaching

### DIFF
--- a/sshmux
+++ b/sshmux
@@ -54,7 +54,7 @@ fi
 RETRY_IN=1
 INIT_TIME=`date +%s`
 LAST_FAIL_TIME=$INIT_TIME
-while ! ssh $SSHMUX_ARGS -o ConnectTimeout=0 -o ServerAliveInterval=5 -o ServerAliveCountmax=2 -t "export PATH=\$PATH:$TMUX_PATH; tmux -2 attach -t $T_ARG || tmux -2 new -s $T_ARG" 2>/tmp/.sshmux_log
+while ! ssh $SSHMUX_ARGS -o ConnectTimeout=0 -o ServerAliveInterval=5 -o ServerAliveCountmax=2 -t "export PATH=\$PATH:$TMUX_PATH; tmux -2 attach -t '=$T_ARG' || tmux -2 new -s $T_ARG" 2>/tmp/.sshmux_log
 do
     CURRENT_TIME=`date +%s`
     if [ $CURRENT_TIME -lt $(($INIT_TIME + 10)) ]; then


### PR DESCRIPTION
...otherwise tmux will allow prefix matches, e.g. an existing session `foobar` will be attached when session `foo` is requested.

In the context of sshmux, prefix matching doesn't make sense. If the session doesn't exist sshmux goes on to create it with the given session name, so users won't be able to reliably use the prefix matching functionality anyway.

The quotation marks are to avoid zsh `=` expansion; see [here](http://zsh.sourceforge.net/Doc/Release/Expansion.html#g_t_0060_003d_0027-expansion).